### PR TITLE
Closes #12 Mark duplicate: Pipeline scheduling conflict

### DIFF
--- a/__proto6/BoyerMoore.js
+++ b/__proto6/BoyerMoore.js
@@ -1,0 +1,49 @@
+/*
+ *
+ *
+ *Implementation of the Boyer-Moore String Search Algorithm.
+ *The Boyer–Moore string search algorithm allows linear time in
+ *search by skipping indices when searching inside a string for a pattern.
+ *
+ *
+ *
+ *
+ **/
+const buildBadMatchTable = (str) => {
+  const tableObj = {}
+  const strLength = str.length
+  for (let i = 0; i < strLength - 1; i++) {
+    tableObj[str[i]] = strLength - 1 - i
+  }
+  if (tableObj[str[strLength - 1]] === undefined) {
+    tableObj[str[strLength - 1]] = strLength
+  }
+  return tableObj
+}
+
+const boyerMoore = (str, pattern) => {
+  const badMatchTable = buildBadMatchTable(pattern)
+  let offset = 0
+  const patternLastIndex = pattern.length - 1
+  const maxOffset = str.length - pattern.length
+  // if the offset is bigger than maxOffset, cannot be found
+  while (offset <= maxOffset) {
+    let scanIndex = 0
+    while (pattern[scanIndex] === str[scanIndex + offset]) {
+      if (scanIndex === patternLastIndex) {
+        // found at this index
+        return offset
+      }
+      scanIndex++
+    }
+    const badMatchString = str[offset + patternLastIndex]
+    if (badMatchTable[badMatchString]) {
+      // increase the offset if it exists
+      offset += badMatchTable[badMatchString]
+    } else {
+      offset++
+    }
+  }
+  return -1
+}
+export { boyerMoore }

--- a/__proto6/readme.md
+++ b/__proto6/readme.md
@@ -1,0 +1,6 @@
+Used for resizing images. It assigns to each location the intensity of its nearest neighbor in original image. Refer [Gonzalez DIP Book](https://www.pearson.com/us/higher-education/program/Gonzalez-Digital-Image-Processing-4th-Edition/PGM241219.html) chapter 1.
+
+Basic algorithm is as follows:
+
+*For every pixel in resized image, we find the coordinate mapping in original image and copy over the pixel intensity from         there to pixel in output image.*
+

--- a/__proto6/tilingproblem_test.go
+++ b/__proto6/tilingproblem_test.go
@@ -1,0 +1,38 @@
+package dynamic_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/dynamic"
+)
+
+type testCaseTilingProblem struct {
+	n        int
+	expected int
+}
+
+func getTilingProblemTestCases() []testCaseTilingProblem {
+	return []testCaseTilingProblem{
+		{1, 1},   // Base case: 1 way to tile a 2x1 grid
+		{2, 2},   // 2 ways to tile a 2x2 grid
+		{3, 3},   // 3 ways to tile a 2x3 grid
+		{4, 5},   // 5 ways to tile a 2x4 grid
+		{5, 8},   // 8 ways to tile a 2x5 grid
+		{6, 13},  // 13 ways to tile a 2x6 grid
+		{10, 89}, // 89 ways to tile a 2x10 grid
+		{0, 1},   // Edge case: 1 way to tile a 2x0 grid (no tiles)
+		{7, 21},  // 21 ways to tile a 2x7 grid
+		{8, 34},  // 34 ways to tile a 2x8 grid
+	}
+}
+
+func TestTilingProblem(t *testing.T) {
+	t.Run("Tiling Problem test cases", func(t *testing.T) {
+		for _, tc := range getTilingProblemTestCases() {
+			actual := dynamic.TilingProblem(tc.n)
+			if actual != tc.expected {
+				t.Errorf("TilingProblem(%d) = %d; expected %d", tc.n, actual, tc.expected)
+			}
+		}
+	})
+}


### PR DESCRIPTION
12 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.